### PR TITLE
Auto-publish features on main when manifest version bumps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,54 @@
 name: "Release dev container features & Generate Documentation"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**/devcontainer-feature.json"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+      bumped: ${{ steps.diff.outputs.bumped }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: "Detect version bumps in feature manifests"
+        id: diff
+        run: |
+          set -euo pipefail
+          changed=false
+          bumped=""
+          while IFS= read -r manifest; do
+            [ -f "$manifest" ] || continue
+            new_ver=$(jq -r '.version // empty' "$manifest")
+            old_ver=$(git show "${{ github.event.before }}:$manifest" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)
+            if [ -n "$new_ver" ] && [ "$new_ver" != "$old_ver" ]; then
+              feature=$(basename "$(dirname "$manifest")")
+              echo "Version bump: $feature ${old_ver:-<none>} -> $new_ver"
+              changed=true
+              bumped="${bumped:+$bumped,}$feature@$new_ver"
+            fi
+          done < <(find src -name 'devcontainer-feature.json')
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "bumped=$bumped" >> "$GITHUB_OUTPUT"
+          if [ "$changed" = "false" ]; then
+            echo "::notice::No version bump detected in any feature manifest; skipping publish."
+          else
+            echo "::notice::Publishing bumped features: $bumped"
+          fi
+
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: detect
+    if: needs.detect.outputs.changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,7 +63,7 @@ jobs:
           publish-features: "true"
           base-path-to-features: "./src"
           generate-docs: "true"
-          
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude-code",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Claude Code + Credentials Bridge",
     "description": "Pre-warms a Claude Code binary cache in /opt during image build, runs `claude install <channel>` as the target user on onCreate (prebuild-cacheable), and forwards host OAuth credentials + workspace trust + remote-control + auto-mode on postCreate/postStart.",
     "options": {


### PR DESCRIPTION
## Summary
- Switches `release.yaml` from `workflow_dispatch` to `push` on `main`, scoped via path filter to `src/**/devcontainer-feature.json`.
- Adds a `detect` job that compares each feature manifest's `version` against the previous commit. The `deploy` job (devcontainers/action@v1 + auto-doc PR) only runs when at least one feature's version actually changed — manifest edits without a bump no longer trigger a republish.
- Adds a `concurrency: release-${{ github.ref }}` group to serialize overlapping merges.
- Bumps `claude-code` to `1.1.1` so the first auto-release fires immediately after this lands on `main`.

## Test plan
- [ ] Merge → confirm `release` workflow triggers automatically.
- [ ] Confirm `detect` job logs `claude-code <none|1.1.0> -> 1.1.1` and sets `changed=true`.
- [ ] Confirm `devcontainers/action@v1` publishes `claude-code:1.1.1` to GHCR.
- [ ] Confirm the auto-doc PR is opened (or no-op if README unchanged).
- [ ] Push a follow-up commit touching only `NOTES.md` or `install.sh` (no manifest change) → workflow does not trigger.
- [ ] Push a manifest edit without bumping `version` → workflow triggers, `detect` sets `changed=false`, `deploy` is skipped.