### PR TITLE
Skip first-run wizard inside container

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Selected options (full list in [`src/claude-code/devcontainer-feature.json`](src
 | `remoteControlServer` | `false` | Spawns `claude remote-control --spawn worktree` as a long-running daemon (workspace must be a git repo). |
 | `marketplaces` | `""` | Comma-separated list passed to `claude plugin marketplace add <item>` (e.g. `anthropics/claude-code,my-org/internal`). |
 | `plugins` | `""` | Comma-separated `<plugin>@<marketplace>` items passed to `claude plugin install`. |
+| `forwardHostOnboarding` | `true` | Carry the host's first-run wizard state (`theme`, `tipsHistory`, `firstStartTime`, `editorMode`, …) into the container so `claude` skips the theme picker / onboarding on first invocation. |
+| `theme` | `dark` | Theme written to `~/.claude.json`. Non-empty values override what `forwardHostOnboarding` copied from the host (`""` = leave untouched). Final safety net forces `"dark"` if no value is set anywhere, so the picker is guaranteed not to appear. |
 
 > **Host requirement:** the Feature reads host OAuth tokens via bind mounts of `$HOME/.claude.json` and `$HOME/.claude/` (the lifecycle scripts only read from them — the Feature manifest cannot declare them `readonly` at the OS level, see [`NOTES.md`](src/claude-code/NOTES.md)). **macOS hosts are not supported** (Claude Code stores tokens in the Keychain, not on disk). On **Windows hosts**, open the project via VS Code's Remote-WSL extension (Claude Code lives inside the WSL distro, not under `%USERPROFILE%`) — see [`NOTES.md`](src/claude-code/NOTES.md#windows-hosts-use-remote-wsl). See [`NOTES.md`](src/claude-code/NOTES.md) for full platform compatibility and edge-case behavior.
 

--- a/src/claude-code/NOTES.md
+++ b/src/claude-code/NOTES.md
@@ -14,10 +14,14 @@ Container lifecycle:
                ── (prebuild-cacheable: result is baked into the prebuild image)
 
     postCreate ── credentials + minimal .claude.json from host bind mount
+               ── wizard-state fields (theme, firstStartTime, tipsHistory, …)
+                  carried forward so first `claude` invocation skips onboarding
                ── marketplace add → plugin install (in that order)
 
     postStart  ── token refresh (if host has newer `expiresAt`)
                ── workspace trust + remoteDialogSeen in ~/.claude.json
+               ── idempotent wizard-state nachziehen (handles host re-login
+                  or older Feature versions that did not write theme)
                ── permissions.defaultMode + remoteControlAtStartup +
                   skipAutoPermissionPrompt / skipDangerousModePermissionPrompt
                   in ~/.claude/settings.json
@@ -80,6 +84,8 @@ In that mode `${localEnv:HOME}` is `/home/<wsl-user>` (the WSL home where Claude
 - `remoteControlServer=true` spawns a long-running `claude remote-control --spawn worktree` *daemon* in `postStart` even when no user is at the terminal. PID + log at `~/.claude/remote-control.{pid,log}`.
 
 **`marketplaces` / `plugins`** — comma-separated strings (devcontainer Feature options do not support native arrays). Items are trimmed of whitespace; empty items are skipped. Order is preserved. Both are only attempted if the credential setup did not soft-fail.
+
+**`forwardHostOnboarding` / `theme`** — suppress the first-run wizard inside the container. A valid login on the host is *not* enough on its own: Claude Code shows the theme picker (and other onboarding dialogs) whenever fields like `theme`, `firstStartTime`, or `tipsHistory` are absent from `~/.claude.json`. With `forwardHostOnboarding=true` (default), `postCreate.sh` copies those wizard-state fields from the host into the container, and `postStart.sh` idempotently nachzieht missing ones on every start (also fixes containers created by older Feature versions that did not write them). `theme` is an option-level override: any non-empty value (default `"dark"`) wins over the host's choice, which is useful for matching the IDE's color scheme regardless of what was picked on the host. As a final safety net, if `theme` would still be empty after all merges, `postStart.sh` forces it to `"dark"` so the picker is guaranteed not to appear.
 
 ## Known upstream issues
 

--- a/src/claude-code/README.md
+++ b/src/claude-code/README.md
@@ -1,7 +1,7 @@
 
 # Claude Code + Credentials Bridge (claude-code)
 
-Pre-warms a Claude Code binary cache in /opt during image build, runs `claude install <channel>` as the target user on onCreate (prebuild-cacheable), and forwards host OAuth credentials + workspace trust + remote-control + auto-mode on postCreate/postStart.
+Pre-warms a Claude Code binary cache in /opt during image build, runs `claude install <channel>` as the target user on onCreate (prebuild-cacheable), and forwards host OAuth credentials + workspace trust + remote-control + auto-mode on postCreate/postStart. Skips the first-run wizard by carrying the host's onboarding state (theme, tips, editor mode, …) into the container.
 
 ## Example Usage
 
@@ -22,6 +22,8 @@ Pre-warms a Claude Code binary cache in /opt during image build, runs `claude in
 | remoteControlServer | When true, postStart spawns `claude remote-control --spawn worktree` as a long-running background daemon under the target user. Requires the workspace to be a git repository. PID and log under ~/.claude/remote-control.{pid,log}. Independent of the `remoteControl` option above. | boolean | false |
 | marketplaces | Comma-separated list of Claude Code plugin marketplaces to add after credential setup in postCreate. Each item is passed to `claude plugin marketplace add <item>`. Accepts GitHub shorthand (owner/repo), URLs, or local paths. Example: "anthropics/claude-code,my-org/internal" | string | - |
 | plugins | Comma-separated list of plugins to install after marketplaces are added. Each item is passed to `claude plugin install <item>` in the format `<plugin>@<marketplace>`. Example: "formatter@anthropics/claude-code,linter@my-org" | string | - |
+| forwardHostOnboarding | When true (default), postCreate/postStart copy the host's first-run wizard state (theme, tipsHistory, firstStartTime, editorMode, autoUpdates, verbose, previewFeaturesOptInList, subscriptionNoticeCount, bypassPermissionsModeAccepted, hasAvailableSubscription) into the container's ~/.claude.json. Without this the first `claude` invocation re-runs the theme picker / onboarding even though credentials are already present. | boolean | true |
+| theme | Theme written to ~/.claude.json (suppresses the first-run theme picker). Empty string = do not touch the setting; rely on forwardHostOnboarding to source it from the host instead. Default 'dark' guarantees the wizard is skipped even when the host has no .claude.json yet (e.g. logged in via a different mechanism). | string | dark |
 
 > **⚠️ macOS hosts are not supported.** Claude Code on macOS stores OAuth tokens in the system Keychain, not in a file under `~/.claude/`. This Feature reads credentials via a read-only bind mount of `~/.claude/.credentials.json` — which simply does not exist on a macOS host. Use a Linux host, a Windows host with Claude Code installed natively, or WSL2 (with Claude Code installed inside the WSL distribution).
 
@@ -39,10 +41,14 @@ Container lifecycle:
                ── (prebuild-cacheable: result is baked into the prebuild image)
 
     postCreate ── credentials + minimal .claude.json from host bind mount
+               ── wizard-state fields (theme, firstStartTime, tipsHistory, …)
+                  carried forward so first `claude` invocation skips onboarding
                ── marketplace add → plugin install (in that order)
 
     postStart  ── token refresh (if host has newer `expiresAt`)
                ── workspace trust + remoteDialogSeen in ~/.claude.json
+               ── idempotent wizard-state nachziehen (handles host re-login
+                  or older Feature versions that did not write theme)
                ── permissions.defaultMode + remoteControlAtStartup +
                   skipAutoPermissionPrompt / skipDangerousModePermissionPrompt
                   in ~/.claude/settings.json
@@ -105,6 +111,8 @@ In that mode `${localEnv:HOME}` is `/home/<wsl-user>` (the WSL home where Claude
 - `remoteControlServer=true` spawns a long-running `claude remote-control --spawn worktree` *daemon* in `postStart` even when no user is at the terminal. PID + log at `~/.claude/remote-control.{pid,log}`.
 
 **`marketplaces` / `plugins`** — comma-separated strings (devcontainer Feature options do not support native arrays). Items are trimmed of whitespace; empty items are skipped. Order is preserved. Both are only attempted if the credential setup did not soft-fail.
+
+**`forwardHostOnboarding` / `theme`** — suppress the first-run wizard inside the container. A valid login on the host is *not* enough on its own: Claude Code shows the theme picker (and other onboarding dialogs) whenever fields like `theme`, `firstStartTime`, or `tipsHistory` are absent from `~/.claude.json`. With `forwardHostOnboarding=true` (default), `postCreate.sh` copies those wizard-state fields from the host into the container, and `postStart.sh` idempotently nachzieht missing ones on every start (also fixes containers created by older Feature versions that did not write them). `theme` is an option-level override: any non-empty value (default `"dark"`) wins over the host's choice, which is useful for matching the IDE's color scheme regardless of what was picked on the host. As a final safety net, if `theme` would still be empty after all merges, `postStart.sh` forces it to `"dark"` so the picker is guaranteed not to appear.
 
 ## Known upstream issues
 

--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "id": "claude-code",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "name": "Claude Code + Credentials Bridge",
-    "description": "Pre-warms a Claude Code binary cache in /opt during image build, runs `claude install <channel>` as the target user on onCreate (prebuild-cacheable), and forwards host OAuth credentials + workspace trust + remote-control + auto-mode on postCreate/postStart.",
+    "description": "Pre-warms a Claude Code binary cache in /opt during image build, runs `claude install <channel>` as the target user on onCreate (prebuild-cacheable), and forwards host OAuth credentials + workspace trust + remote-control + auto-mode on postCreate/postStart. Skips the first-run wizard by carrying the host's onboarding state (theme, tips, editor mode, …) into the container.",
     "options": {
         "targetUser": {
             "type": "string",
@@ -40,6 +40,17 @@
             "type": "string",
             "default": "",
             "description": "Comma-separated list of plugins to install after marketplaces are added. Each item is passed to `claude plugin install <item>` in the format `<plugin>@<marketplace>`. Example: \"formatter@anthropics/claude-code,linter@my-org\""
+        },
+        "forwardHostOnboarding": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true (default), postCreate/postStart copy the host's first-run wizard state (theme, tipsHistory, firstStartTime, editorMode, autoUpdates, verbose, previewFeaturesOptInList, subscriptionNoticeCount, bypassPermissionsModeAccepted, hasAvailableSubscription) into the container's ~/.claude.json. Without this the first `claude` invocation re-runs the theme picker / onboarding even though credentials are already present."
+        },
+        "theme": {
+            "type": "string",
+            "default": "dark",
+            "enum": ["", "dark", "light", "dark-daltonized", "light-daltonized", "dark-ansi", "light-ansi"],
+            "description": "Theme written to ~/.claude.json (suppresses the first-run theme picker). Empty string = do not touch the setting; rely on forwardHostOnboarding to source it from the host instead. Default 'dark' guarantees the wizard is skipped even when the host has no .claude.json yet (e.g. logged in via a different mechanism)."
         }
     },
     "containerEnv": {

--- a/src/claude-code/install.sh
+++ b/src/claude-code/install.sh
@@ -128,6 +128,8 @@ CONFIG_ENV="${FEATURE_DIR}/config.env"
     printf 'CLAUDE_REMOTE_CONTROL_SERVER=%q\n' "${REMOTECONTROLSERVER-false}"
     printf 'CLAUDE_MARKETPLACES=%q\n'          "${MARKETPLACES-}"
     printf 'CLAUDE_PLUGINS=%q\n'               "${PLUGINS-}"
+    printf 'CLAUDE_FORWARD_HOST_ONBOARDING=%q\n' "${FORWARDHOSTONBOARDING-true}"
+    printf 'CLAUDE_THEME=%q\n'                 "${THEME-dark}"
 } > "$CONFIG_ENV"
 chmod 0644 "$CONFIG_ENV"
 

--- a/src/claude-code/postCreate.sh
+++ b/src/claude-code/postCreate.sh
@@ -31,6 +31,9 @@ if ! jq -e '.claudeAiOauth.accessToken and .claudeAiOauth.refreshToken' \
 fi
 
 # --- Build minimal .claude.json ------------------------------------------
+# Basis: Account + onboarding-Flag. Ohne weitere Felder reicht das NICHT, um
+# den First-Run-Wizard zu unterdruecken — Claude Code zeigt den Theme-Picker,
+# wenn .theme fehlt, und ggf. Tip-Dialoge, wenn .tipsHistory leer ist.
 extracted_json="$(jq '{
     userID:                 .userID,
     oauthAccount:           .oauthAccount,
@@ -42,6 +45,38 @@ if ! printf '%s' "$extracted_json" | \
     warn "could not extract userID / oauthAccount from ${HOST_JSON} — skipping"
     exit 0
 fi
+
+# Wizard-state vom Host uebernehmen (Whitelist) — sonst kommt der Wizard
+# trotz vorhandenem Login. Workspace-spezifische Felder (projects, mcpServers)
+# bewusst nicht uebernehmen — die werden in postStart.sh per-Workspace gesetzt.
+if [[ "${CLAUDE_FORWARD_HOST_ONBOARDING:-true}" == "true" ]]; then
+    extracted_json="$(printf '%s' "$extracted_json" | jq \
+        --slurpfile host "$HOST_JSON" \
+        '. + ($host[0] | {
+            theme,
+            firstStartTime,
+            tipsHistory,
+            editorMode,
+            autoUpdates,
+            verbose,
+            previewFeaturesOptInList,
+            subscriptionNoticeCount,
+            bypassPermissionsModeAccepted,
+            hasAvailableSubscription
+        } | with_entries(select(.value != null)))')"
+fi
+
+# Option-Override fuer theme (gewinnt gegen Host).
+if [[ -n "${CLAUDE_THEME:-}" ]]; then
+    extracted_json="$(printf '%s' "$extracted_json" | \
+        jq --arg t "$CLAUDE_THEME" '.theme = $t')"
+fi
+
+# Fallback fuer firstStartTime — wenn weder Host noch Option gesetzt, das
+# eine Feld, das Claude Code als Wizard-Trigger nutzt, mit "jetzt" fuellen.
+extracted_json="$(printf '%s' "$extracted_json" | jq '
+    if .firstStartTime == null then .firstStartTime = (now * 1000 | floor) else . end
+')"
 
 # --- Install ---------------------------------------------------------------
 # Harden TARGET_DIR einmalig — install_for_target laesst Parent-Dirs

--- a/src/claude-code/postStart.sh
+++ b/src/claude-code/postStart.sh
@@ -71,6 +71,9 @@ fi
 
 # --- (2) .claude.json: bei userID-Wechsel Account-Felder mergen -----------
 #       (nicht ersetzen — sonst gingen Trust-/RemoteControl-Felder verloren)
+FORWARD_HOST_ONBOARDING="${CLAUDE_FORWARD_HOST_ONBOARDING:-true}"
+THEME_OPT="${CLAUDE_THEME:-}"
+
 if [[ "$HOST_CREDS_OK" == "1" && -r "$HOST_JSON" ]] && \
    jq -e . "$HOST_JSON" >/dev/null 2>&1; then
     host_uid=$(jq -r '.userID // empty' "$HOST_JSON")
@@ -92,6 +95,61 @@ if [[ "$HOST_CREDS_OK" == "1" && -r "$HOST_JSON" ]] && \
         install_for_target "$tmp_file" "$TARGET_JSON" 600
         rm -f "$tmp_file"
     fi
+fi
+
+# --- (2b) Wizard-state idempotent nachziehen ------------------------------
+#       Schliesst zwei Luecken:
+#         - aeltere Feature-Versionen haben kein theme/firstStartTime
+#           geschrieben (re-run auf persistent volume).
+#         - Host wurde nach Container-Create neu eingeloggt (postCreate
+#           war bereits durch, hat aber nur Account-Felder uebernommen).
+#       Bestehende Werte werden NICHT ueberschrieben (ausser Theme-Option).
+current="$(read_json_or_empty "$TARGET_JSON")"
+desired_wizard="$current"
+
+if [[ "$FORWARD_HOST_ONBOARDING" == "true" && -r "$HOST_JSON" ]] && \
+   jq -e . "$HOST_JSON" >/dev/null 2>&1; then
+    desired_wizard="$(printf '%s' "$desired_wizard" | jq \
+        --slurpfile host "$HOST_JSON" \
+        '($host[0] | {
+            theme,
+            firstStartTime,
+            tipsHistory,
+            editorMode,
+            autoUpdates,
+            verbose,
+            previewFeaturesOptInList,
+            subscriptionNoticeCount,
+            bypassPermissionsModeAccepted,
+            hasAvailableSubscription
+        } | with_entries(select(.value != null))) as $h
+         | $h * .')"
+fi
+
+# Theme-Option wirkt als Override (gewinnt sowohl ueber Host als auch
+# ueber bestehenden Wert) — sonst bliebe ein vom Host uebernommener Wert
+# trotz explizitem Option-Wert.
+if [[ -n "$THEME_OPT" ]]; then
+    desired_wizard="$(printf '%s' "$desired_wizard" | \
+        jq --arg t "$THEME_OPT" '.theme = $t')"
+fi
+
+# Sicherheitsnetz: wenn theme nach all dem immer noch leer ist (z.B. weder
+# Host noch Option setzen es), default auf "dark" — dann kommt der Picker
+# garantiert nicht.
+desired_wizard="$(printf '%s' "$desired_wizard" | jq '
+    if (.theme // "") == "" then .theme = "dark" else . end
+  | if .hasCompletedOnboarding != true then .hasCompletedOnboarding = true else . end
+  | if .firstStartTime == null then .firstStartTime = (now * 1000 | floor) else . end
+')"
+
+if [[ "$(printf '%s' "$current"        | jq -S .)" != \
+      "$(printf '%s' "$desired_wizard" | jq -S .)" ]]; then
+    log "patching .claude.json wizard fields"
+    tmp_file="$(mktemp)"
+    printf '%s\n' "$desired_wizard" > "$tmp_file"
+    install_for_target "$tmp_file" "$TARGET_JSON" 600
+    rm -f "$tmp_file"
 fi
 
 # --- (3) Workspace-Trust + remoteDialogSeen in .claude.json ---------------

--- a/test/claude-code/test.sh
+++ b/test/claude-code/test.sh
@@ -85,5 +85,15 @@ check "permissions.defaultMode = 'auto' in settings.json (default)" \
 check "skipAutoPermissionPrompt = true in settings.json (default with auto mode)" \
     bash -c "jq -e '.skipAutoPermissionPrompt == true' '${TARGET_HOME}/.claude/settings.json'"
 
+# --- Wizard-Suppression: erstes `claude` darf keinen Wizard zeigen --------
+check "hasCompletedOnboarding = true in .claude.json (default)" \
+    bash -c "jq -e '.hasCompletedOnboarding == true' '${TARGET_HOME}/.claude.json'"
+
+check "theme = 'dark' in .claude.json (default option)" \
+    bash -c "jq -e '.theme == \"dark\"' '${TARGET_HOME}/.claude.json'"
+
+check "firstStartTime set in .claude.json" \
+    bash -c "jq -e '(.firstStartTime // 0) > 0' '${TARGET_HOME}/.claude.json'"
+
 # Report result
 reportResults


### PR DESCRIPTION
## Summary
- Adds wizard-state forwarding so `claude` inside the container does not re-run the theme picker / onboarding even when the host is already logged in.
- New Feature options:
  - `forwardHostOnboarding` (bool, default `true`) — copies whitelisted wizard fields (`theme`, `firstStartTime`, `tipsHistory`, `editorMode`, `autoUpdates`, `verbose`, `previewFeaturesOptInList`, `subscriptionNoticeCount`, `bypassPermissionsModeAccepted`, `hasAvailableSubscription`) from the host into `~/.claude.json`.
  - `theme` (enum, default `"dark"`) — option-level override; non-empty value wins over what the host had. Empty string leaves the field untouched (falls back to host or, as a final safety net in `postStart.sh`, `"dark"` so the picker is guaranteed not to appear).
- `postStart.sh` idempotently nachzieht missing wizard fields on every start, fixing containers from older Feature versions and host re-logins after `postCreate` already ran.
- Adds `firstStartTime = now` fallback if neither host nor option provides a value.
- Bumps version `1.1.1` → `1.2.0` and asserts the new behavior in the default autogenerated test.

## Root cause
Previously `postCreate.sh` extracted only `userID`, `oauthAccount`, `hasCompletedOnboarding` from the host `.claude.json`. Claude Code's wizard, however, also gates on the *presence* of `theme` / `firstStartTime` — both missing in the minimal extract — so the picker fired on first invocation despite valid credentials.

## Test plan
- [ ] CI autogenerated test passes (now also asserts `theme == "dark"`, `firstStartTime > 0`, `hasCompletedOnboarding == true` against the stubbed host fixture).
- [ ] CI scenario tests pass (no assertions changed; defaults are non-empty `theme=dark` + `forwardHostOnboarding=true`).
- [ ] Manual: rebuild container against host with completed onboarding → first `claude` invocation lands directly at the prompt, no theme picker.
- [ ] Manual: rebuild container against host without `~/.claude.json` → `theme=dark` still applied, wizard skipped.
- [ ] Manual: opt out via `"theme": ""` + `"forwardHostOnboarding": false` → behavior matches the explicit-untouched contract.