### PR TITLE
Trust /workspaces + subdirs to silence per-folder trust dialog

### DIFF
--- a/src/claude-code/NOTES.md
+++ b/src/claude-code/NOTES.md
@@ -73,6 +73,7 @@ In that mode `${localEnv:HOME}` is `/home/<wsl-user>` (the WSL home where Claude
 | Target user differs between image build and runtime | Auto-detect runs on every lifecycle hook; no hardcoded UID. |
 | Re-run on persistent volume | `claude install` skipped if `~/.local/bin/claude` already exists. Token refresh only writes when host `expiresAt` is strictly greater than container's. |
 | Host account switched (different `userID`) | `postStart` merges the new account fields into the existing `.claude.json` without losing workspace trust + remote-control settings. |
+| Workspace trust dialog | `postStart` writes `hasTrustDialogAccepted=true` + `hasCompletedProjectOnboarding=true` under `.projects[<path>]` for the resolved workspace, its `realpath` (covers symlinked mounts), `/workspaces` itself, and every immediate `/workspaces/*` subdir — so opening a sibling repo in the same dev container also stays trusted. |
 | Concurrent reads during token refresh | `postStart.sh` writes (credential refresh, `.claude.json` patch, `settings.json` patch) go through a `mktemp` + atomic `mv` helper on the same filesystem. The initial install in `postCreate.sh` uses plain `cp` / shell redirects after the host mount has been validated. |
 
 ## Configuration option notes

--- a/src/claude-code/README.md
+++ b/src/claude-code/README.md
@@ -100,6 +100,7 @@ In that mode `${localEnv:HOME}` is `/home/<wsl-user>` (the WSL home where Claude
 | Target user differs between image build and runtime | Auto-detect runs on every lifecycle hook; no hardcoded UID. |
 | Re-run on persistent volume | `claude install` skipped if `~/.local/bin/claude` already exists. Token refresh only writes when host `expiresAt` is strictly greater than container's. |
 | Host account switched (different `userID`) | `postStart` merges the new account fields into the existing `.claude.json` without losing workspace trust + remote-control settings. |
+| Workspace trust dialog | `postStart` writes `hasTrustDialogAccepted=true` + `hasCompletedProjectOnboarding=true` under `.projects[<path>]` for the resolved workspace, its `realpath` (covers symlinked mounts), `/workspaces` itself, and every immediate `/workspaces/*` subdir — so opening a sibling repo in the same dev container also stays trusted. |
 | Concurrent reads during token refresh | `postStart.sh` writes (credential refresh, `.claude.json` patch, `settings.json` patch) go through a `mktemp` + atomic `mv` helper on the same filesystem. The initial install in `postCreate.sh` uses plain `cp` / shell redirects after the host mount has been validated. |
 
 ## Configuration option notes

--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude-code",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Claude Code + Credentials Bridge",
     "description": "Pre-warms a Claude Code binary cache in /opt during image build, runs `claude install <channel>` as the target user on onCreate (prebuild-cacheable), and forwards host OAuth credentials + workspace trust + remote-control + auto-mode on postCreate/postStart. Skips the first-run wizard by carrying the host's onboarding state (theme, tips, editor mode, …) into the container. Wizard-related Feature options (theme, defaultMode) default to empty so the host's completed wizard state wins; set them explicitly to override.",
     "options": {

--- a/src/claude-code/postStart.sh
+++ b/src/claude-code/postStart.sh
@@ -173,11 +173,14 @@ REMOTE_CONTROL="${CLAUDE_REMOTE_CONTROL:-true}"
 # Liste der zu trustenden Pfade aufbauen (Dedup ueber assoziatives Array).
 declare -A trust_set=()
 add_trust_path() {
+    # Unter `set -e` muss diese Funktion immer mit 0 zurueckkehren — eine
+    # nicht-zutreffende Guard-Bedingung ist kein Fehler.
     local p="$1"
-    [[ -z "$p" || "$p" == "/" ]] && return
-    [[ "$p" == /* ]] || return
-    [[ -d "$p" ]] || return
+    if [[ -z "$p" || "$p" == "/" ]]; then return 0; fi
+    if [[ "$p" != /* ]];             then return 0; fi
+    if [[ ! -d "$p" ]];              then return 0; fi
     trust_set["$p"]=1
+    return 0
 }
 
 add_trust_path "$WORKSPACE"

--- a/src/claude-code/postStart.sh
+++ b/src/claude-code/postStart.sh
@@ -153,14 +153,44 @@ if [[ "$(printf '%s' "$current"        | jq -S .)" != \
 fi
 
 # --- (3) Workspace-Trust + remoteDialogSeen in .claude.json ---------------
-#       Workspace-Trust (per Projekt):  immer (wenn Workspace-Pfad bekannt)
+#       Workspace-Trust (per Projekt):  fuer den aufgeloesten Workspace,
+#                                       seinen realpath UND /workspaces
+#                                       inkl. allen unmittelbaren Subdirs.
+#                                       Claude prueft Trust per exact-path
+#                                       gegen .projects[<cwd>] — abweichende
+#                                       Pfade (Symlink, anderes Repo im
+#                                       selben /workspaces) wuerden sonst
+#                                       erneut den Dialog zeigen. Felder die
+#                                       das Binary tatsaechlich liest:
+#                                       hasTrustDialogAccepted +
+#                                       hasCompletedProjectOnboarding.
 #       remoteDialogSeen (top-level):   nur wenn remoteControl=true
 #                                       (sonst erscheint der einmalige
 #                                       Remote-Control-Hinweisdialog).
 WORKSPACE="$(resolve_workspace_folder)"
 REMOTE_CONTROL="${CLAUDE_REMOTE_CONTROL:-true}"
 
-[[ -z "$WORKSPACE" ]] && warn "no workspace path resolvable (PWD invalid, /workspaces ambiguous) — workspace-trust skipped"
+# Liste der zu trustenden Pfade aufbauen (Dedup ueber assoziatives Array).
+declare -A trust_set=()
+add_trust_path() {
+    local p="$1"
+    [[ -z "$p" || "$p" == "/" ]] && return
+    [[ "$p" == /* ]] || return
+    [[ -d "$p" ]] || return
+    trust_set["$p"]=1
+}
+
+add_trust_path "$WORKSPACE"
+if [[ -n "$WORKSPACE" ]] && command -v realpath >/dev/null 2>&1; then
+    real_ws="$(realpath -m "$WORKSPACE" 2>/dev/null || true)"
+    add_trust_path "$real_ws"
+fi
+if [[ -d /workspaces ]]; then
+    add_trust_path "/workspaces"
+    for d in /workspaces/*/; do
+        [[ -d "$d" ]] && add_trust_path "${d%/}"
+    done
+fi
 
 current="$(read_json_or_empty "$TARGET_JSON")"
 desired="$current"
@@ -173,19 +203,22 @@ fi
 # in der Datei und stiftet Verwirrung. Der echte Wert sitzt in settings.json.
 desired="$(printf '%s' "$desired" | jq 'del(.remoteControlAtStartup)')"
 
-if [[ -n "$WORKSPACE" ]]; then
-    desired="$(printf '%s' "$desired" | jq --arg ws "$WORKSPACE" '
-        .projects = ((.projects // {}) | .[$ws] = ((.[$ws] // {})
-            | .hasTrustDialogAccepted        = true
-            | .hasTrustDialogHooksAccepted   = true
-            | .hasCompletedProjectOnboarding = true
-        ))
-    ')"
+if (( ${#trust_set[@]} == 0 )); then
+    warn "no trustable paths found (PWD invalid, /workspaces missing) — workspace-trust skipped"
+else
+    for p in "${!trust_set[@]}"; do
+        desired="$(printf '%s' "$desired" | jq --arg ws "$p" '
+            .projects = ((.projects // {}) | .[$ws] = ((.[$ws] // {})
+                | .hasTrustDialogAccepted        = true
+                | .hasCompletedProjectOnboarding = true
+            ))
+        ')"
+    done
 fi
 
 if [[ "$(printf '%s' "$current"  | jq -S .)" != \
       "$(printf '%s' "$desired"  | jq -S .)" ]]; then
-    log "patching .claude.json (remoteControl=${REMOTE_CONTROL}, workspace=${WORKSPACE:-<none>})"
+    log "patching .claude.json (remoteControl=${REMOTE_CONTROL}, trusted paths: ${!trust_set[*]:-<none>})"
     tmp_file="$(mktemp)"
     printf '%s\n' "$desired" > "$tmp_file"
     install_for_target "$tmp_file" "$TARGET_JSON" 600

--- a/src/claude-code/postStart.sh
+++ b/src/claude-code/postStart.sh
@@ -170,8 +170,11 @@ fi
 WORKSPACE="$(resolve_workspace_folder)"
 REMOTE_CONTROL="${CLAUDE_REMOTE_CONTROL:-true}"
 
-# Liste der zu trustenden Pfade aufbauen (Dedup ueber assoziatives Array).
-declare -A trust_set=()
+# Liste der zu trustenden Pfade aufbauen (Dedup ueber lineare Suche —
+# bewusst indexed array statt `declare -A`, weil indirekte Expansion
+# `${!arr[*]:-<none>}` von Associative Arrays in einigen bash-Versionen
+# zu "invalid variable name" fuehrt).
+trust_paths=()
 add_trust_path() {
     # Unter `set -e` muss diese Funktion immer mit 0 zurueckkehren — eine
     # nicht-zutreffende Guard-Bedingung ist kein Fehler.
@@ -179,7 +182,11 @@ add_trust_path() {
     if [[ -z "$p" || "$p" == "/" ]]; then return 0; fi
     if [[ "$p" != /* ]];             then return 0; fi
     if [[ ! -d "$p" ]];              then return 0; fi
-    trust_set["$p"]=1
+    local existing
+    for existing in ${trust_paths[@]+"${trust_paths[@]}"}; do
+        if [[ "$existing" == "$p" ]]; then return 0; fi
+    done
+    trust_paths+=("$p")
     return 0
 }
 
@@ -191,7 +198,7 @@ fi
 if [[ -d /workspaces ]]; then
     add_trust_path "/workspaces"
     for d in /workspaces/*/; do
-        [[ -d "$d" ]] && add_trust_path "${d%/}"
+        if [[ -d "$d" ]]; then add_trust_path "${d%/}"; fi
     done
 fi
 
@@ -206,10 +213,10 @@ fi
 # in der Datei und stiftet Verwirrung. Der echte Wert sitzt in settings.json.
 desired="$(printf '%s' "$desired" | jq 'del(.remoteControlAtStartup)')"
 
-if (( ${#trust_set[@]} == 0 )); then
+if [[ ${#trust_paths[@]} -eq 0 ]]; then
     warn "no trustable paths found (PWD invalid, /workspaces missing) — workspace-trust skipped"
 else
-    for p in "${!trust_set[@]}"; do
+    for p in "${trust_paths[@]}"; do
         desired="$(printf '%s' "$desired" | jq --arg ws "$p" '
             .projects = ((.projects // {}) | .[$ws] = ((.[$ws] // {})
                 | .hasTrustDialogAccepted        = true
@@ -219,9 +226,13 @@ else
     done
 fi
 
+trust_summary="<none>"
+if [[ ${#trust_paths[@]} -gt 0 ]]; then
+    trust_summary="${trust_paths[*]}"
+fi
 if [[ "$(printf '%s' "$current"  | jq -S .)" != \
       "$(printf '%s' "$desired"  | jq -S .)" ]]; then
-    log "patching .claude.json (remoteControl=${REMOTE_CONTROL}, trusted paths: ${!trust_set[*]:-<none>})"
+    log "patching .claude.json (remoteControl=${REMOTE_CONTROL}, trusted paths: ${trust_summary})"
     tmp_file="$(mktemp)"
     printf '%s\n' "$desired" > "$tmp_file"
     install_for_target "$tmp_file" "$TARGET_JSON" 600


### PR DESCRIPTION
## Summary

Follow-up to #7. v1.3.0 still left the trust dialog appearing in some setups because we only trusted **one** path (the resolved workspace folder). If Claude's cwd at invocation time differed — symlinked `/workspaces` mount on WSL2, sibling repo opened from the same dev container, parent-walk semantics — the per-folder check would trip and the dialog would reappear.

### Changes
- `postStart` now seeds `.projects[<path>]` for:
  - the resolved workspace folder (as before),
  - its `realpath` (covers symlinked `/workspaces` mounts on WSL2),
  - `/workspaces` itself,
  - every immediate `/workspaces/*/` subdir (covers sibling repos in the same dev container).
- Only the fields the binary actually reads are written — verified by inspecting `strings ~/.local/bin/claude`:
  - `hasTrustDialogAccepted`
  - `hasCompletedProjectOnboarding`
- The previously-set `hasTrustDialogHooksAccepted` is dropped (not present in the binary's string table; was dead weight).
- Bumps feature to **v1.3.1**.

## Test plan
- [ ] CI matrices pass (autogenerated + scenarios)
- [ ] Open dev container locally: Claude no longer prompts for workspace trust on first invocation
- [ ] Open a second repo from `/workspaces/<other>` in the same container: no trust prompt