### PR TITLE
Trust only /workspaces/* subdirs; apply in both postCreate and postStart

### DIFF
--- a/src/claude-code/NOTES.md
+++ b/src/claude-code/NOTES.md
@@ -73,7 +73,7 @@ In that mode `${localEnv:HOME}` is `/home/<wsl-user>` (the WSL home where Claude
 | Target user differs between image build and runtime | Auto-detect runs on every lifecycle hook; no hardcoded UID. |
 | Re-run on persistent volume | `claude install` skipped if `~/.local/bin/claude` already exists. Token refresh only writes when host `expiresAt` is strictly greater than container's. |
 | Host account switched (different `userID`) | `postStart` merges the new account fields into the existing `.claude.json` without losing workspace trust + remote-control settings. |
-| Workspace trust dialog | `postStart` writes `hasTrustDialogAccepted=true` + `hasCompletedProjectOnboarding=true` under `.projects[<path>]` for the resolved workspace, its `realpath` (covers symlinked mounts), `/workspaces` itself, and every immediate `/workspaces/*` subdir — so opening a sibling repo in the same dev container also stays trusted. |
+| Workspace trust dialog | `postStart` writes `hasTrustDialogAccepted=true` + `hasCompletedProjectOnboarding=true` under `.projects[<path>]` for every immediate subdir of `/workspaces` — Claude checks trust per exact-path against the cwd, so the `/workspaces` parent itself is intentionally **not** added (would be a dead entry), and every repo opened from `/workspaces/*` stays trusted. |
 | Concurrent reads during token refresh | `postStart.sh` writes (credential refresh, `.claude.json` patch, `settings.json` patch) go through a `mktemp` + atomic `mv` helper on the same filesystem. The initial install in `postCreate.sh` uses plain `cp` / shell redirects after the host mount has been validated. |
 
 ## Configuration option notes

--- a/src/claude-code/README.md
+++ b/src/claude-code/README.md
@@ -106,7 +106,7 @@ In that mode `${localEnv:HOME}` is `/home/<wsl-user>` (the WSL home where Claude
 | Target user differs between image build and runtime | Auto-detect runs on every lifecycle hook; no hardcoded UID. |
 | Re-run on persistent volume | `claude install` skipped if `~/.local/bin/claude` already exists. Token refresh only writes when host `expiresAt` is strictly greater than container's. |
 | Host account switched (different `userID`) | `postStart` merges the new account fields into the existing `.claude.json` without losing workspace trust + remote-control settings. |
-| Workspace trust dialog | `postStart` writes `hasTrustDialogAccepted=true` + `hasCompletedProjectOnboarding=true` under `.projects[<path>]` for the resolved workspace, its `realpath` (covers symlinked mounts), `/workspaces` itself, and every immediate `/workspaces/*` subdir — so opening a sibling repo in the same dev container also stays trusted. |
+| Workspace trust dialog | `postStart` writes `hasTrustDialogAccepted=true` + `hasCompletedProjectOnboarding=true` under `.projects[<path>]` for every immediate subdir of `/workspaces` — Claude checks trust per exact-path against the cwd, so the `/workspaces` parent itself is intentionally **not** added (would be a dead entry), and every repo opened from `/workspaces/*` stays trusted. |
 | Concurrent reads during token refresh | `postStart.sh` writes (credential refresh, `.claude.json` patch, `settings.json` patch) go through a `mktemp` + atomic `mv` helper on the same filesystem. The initial install in `postCreate.sh` uses plain `cp` / shell redirects after the host mount has been validated. |
 
 ## Configuration option notes

--- a/src/claude-code/_lib.sh
+++ b/src/claude-code/_lib.sh
@@ -156,6 +156,70 @@ resolve_workspace_folder() {
     fi
 }
 
+# --- Workspace-Trust auf alle /workspaces/* anwenden ----------------------
+# Schreibt .projects[<subdir>] = { hasTrustDialogAccepted: true,
+# hasCompletedProjectOnboarding: true } in TARGET_JSON fuer jeden
+# unmittelbaren Unterordner von /workspaces. Idempotent.
+#
+# Wird sowohl aus postCreate.sh als auch postStart.sh aufgerufen — beim
+# Create steht .claude.json u.U. noch nicht (z.B. weil Host-Creds fehlen
+# und postCreate frueh exitet); deshalb startet das Skript notfalls von
+# einem leeren JSON-Objekt und legt die Datei selbst an.
+#
+# Voraussetzung: resolve_target_paths wurde vorher aufgerufen
+# (TARGET_JSON / TARGET_USER muessen gesetzt sein).
+apply_workspace_trust() {
+    if ! command -v jq >/dev/null 2>&1; then
+        warn "jq not available — workspace-trust skipped"
+        return 0
+    fi
+    if [[ -z "${TARGET_JSON:-}" ]]; then
+        warn "TARGET_JSON not set — call resolve_target_paths first"
+        return 0
+    fi
+    if [[ ! -d /workspaces ]]; then
+        log "no /workspaces directory — workspace-trust skipped"
+        return 0
+    fi
+
+    local trust_paths=() d
+    for d in /workspaces/*/; do
+        if [[ -d "$d" ]]; then trust_paths+=("${d%/}"); fi
+    done
+
+    if [[ ${#trust_paths[@]} -eq 0 ]]; then
+        log "no /workspaces/*/ subdirs found — workspace-trust skipped"
+        return 0
+    fi
+
+    local current desired
+    if [[ -f "$TARGET_JSON" ]] && jq -e . "$TARGET_JSON" >/dev/null 2>&1; then
+        current="$(cat "$TARGET_JSON")"
+    else
+        current='{}'
+    fi
+    desired="$current"
+
+    local p
+    for p in "${trust_paths[@]}"; do
+        desired="$(printf '%s' "$desired" | jq --arg ws "$p" '
+            .projects = ((.projects // {}) | .[$ws] = ((.[$ws] // {})
+                | .hasTrustDialogAccepted        = true
+                | .hasCompletedProjectOnboarding = true
+            ))
+        ')"
+    done
+
+    if [[ "$(printf '%s' "$current" | jq -S .)" != \
+          "$(printf '%s' "$desired" | jq -S .)" ]]; then
+        log "applying workspace-trust for: ${trust_paths[*]}"
+        local tmp; tmp="$(mktemp)"
+        printf '%s\n' "$desired" > "$tmp"
+        install_for_target "$tmp" "$TARGET_JSON" 600
+        rm -f "$tmp"
+    fi
+}
+
 # --- Release-Channel ermitteln --------------------------------------------
 # Praezedenz:
 #   (1) Feature-Option CLAUDE_CHANNEL (wenn non-empty) — Override

--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude-code",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "name": "Claude Code + Credentials Bridge",
     "description": "Pre-warms a Claude Code binary cache in /opt during image build, runs `claude install <channel>` as the target user on onCreate (prebuild-cacheable), and forwards host OAuth credentials + workspace trust + remote-control + auto-mode on postCreate/postStart. Skips the first-run wizard by carrying the host's onboarding state (theme, tips, editor mode, …) into the container. Wizard-related Feature options (theme, defaultMode) default to empty so the host's completed wizard state wins; set them explicitly to override.",
     "options": {
@@ -73,9 +73,15 @@
             "type": "bind"
         }
     ],
-    "onCreateCommand":   "/usr/local/share/claude-code/onCreate.sh",
-    "postCreateCommand": "/usr/local/share/claude-code/postCreate.sh",
-    "postStartCommand":  "/usr/local/share/claude-code/postStart.sh",
+    "onCreateCommand": {
+        "claude-code": "/usr/local/share/claude-code/onCreate.sh"
+    },
+    "postCreateCommand": {
+        "claude-code": "/usr/local/share/claude-code/postCreate.sh"
+    },
+    "postStartCommand": {
+        "claude-code": "/usr/local/share/claude-code/postStart.sh"
+    },
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils"
     ]

--- a/src/claude-code/postCreate.sh
+++ b/src/claude-code/postCreate.sh
@@ -20,6 +20,11 @@ command -v jq >/dev/null 2>&1 || fail "jq is required but not installed"
 
 resolve_target_paths
 
+# --- Workspace-Trust (unabhaengig von Host-Creds) -------------------------
+# Vor dem Soft-Exit-Pfad, damit der Trust-Dialog auch ohne Host-Creds
+# unterdrueckt wird (Claude haengt sonst beim ersten Aufruf am Trust-Prompt).
+apply_workspace_trust
+
 # --- Validate host mount ---------------------------------------------------
 [[ -r "$HOST_CREDS" ]] || { log "no host credentials at ${HOST_CREDS} — skipping"; exit 0; }
 [[ -r "$HOST_JSON"  ]] || { log "no ${HOST_JSON} — skipping";                       exit 0; }

--- a/src/claude-code/postStart.sh
+++ b/src/claude-code/postStart.sh
@@ -152,55 +152,18 @@ if [[ "$(printf '%s' "$current"        | jq -S .)" != \
     rm -f "$tmp_file"
 fi
 
-# --- (3) Workspace-Trust + remoteDialogSeen in .claude.json ---------------
-#       Workspace-Trust (per Projekt):  fuer den aufgeloesten Workspace,
-#                                       seinen realpath UND /workspaces
-#                                       inkl. allen unmittelbaren Subdirs.
-#                                       Claude prueft Trust per exact-path
-#                                       gegen .projects[<cwd>] — abweichende
-#                                       Pfade (Symlink, anderes Repo im
-#                                       selben /workspaces) wuerden sonst
-#                                       erneut den Dialog zeigen. Felder die
-#                                       das Binary tatsaechlich liest:
-#                                       hasTrustDialogAccepted +
-#                                       hasCompletedProjectOnboarding.
-#       remoteDialogSeen (top-level):   nur wenn remoteControl=true
-#                                       (sonst erscheint der einmalige
-#                                       Remote-Control-Hinweisdialog).
-WORKSPACE="$(resolve_workspace_folder)"
+# --- (3a) Workspace-Trust (idempotent re-apply — auch postCreate.sh setzt
+#          das schon beim Container-Create, hier nochmal fuer den Fall dass
+#          der Workspace zwischen den Starts geaendert wurde).
+apply_workspace_trust
+
+# --- (3b) remoteDialogSeen + remoteControlAtStartup-Migration in .claude.json
+#         remoteDialogSeen:  Top-level Flag — nur wenn remoteControl=true
+#                            (sonst erscheint der einmalige Remote-Control-
+#                            Hinweisdialog).
 REMOTE_CONTROL="${CLAUDE_REMOTE_CONTROL:-true}"
-
-# Liste der zu trustenden Pfade aufbauen (Dedup ueber lineare Suche —
-# bewusst indexed array statt `declare -A`, weil indirekte Expansion
-# `${!arr[*]:-<none>}` von Associative Arrays in einigen bash-Versionen
-# zu "invalid variable name" fuehrt).
-trust_paths=()
-add_trust_path() {
-    # Unter `set -e` muss diese Funktion immer mit 0 zurueckkehren — eine
-    # nicht-zutreffende Guard-Bedingung ist kein Fehler.
-    local p="$1"
-    if [[ -z "$p" || "$p" == "/" ]]; then return 0; fi
-    if [[ "$p" != /* ]];             then return 0; fi
-    if [[ ! -d "$p" ]];              then return 0; fi
-    local existing
-    for existing in ${trust_paths[@]+"${trust_paths[@]}"}; do
-        if [[ "$existing" == "$p" ]]; then return 0; fi
-    done
-    trust_paths+=("$p")
-    return 0
-}
-
-add_trust_path "$WORKSPACE"
-if [[ -n "$WORKSPACE" ]] && command -v realpath >/dev/null 2>&1; then
-    real_ws="$(realpath -m "$WORKSPACE" 2>/dev/null || true)"
-    add_trust_path "$real_ws"
-fi
-if [[ -d /workspaces ]]; then
-    add_trust_path "/workspaces"
-    for d in /workspaces/*/; do
-        if [[ -d "$d" ]]; then add_trust_path "${d%/}"; fi
-    done
-fi
+# Workspace-Pfad wird unten in Section (5) (remoteControlServer) gebraucht.
+WORKSPACE="$(resolve_workspace_folder)"
 
 current="$(read_json_or_empty "$TARGET_JSON")"
 desired="$current"
@@ -213,26 +176,9 @@ fi
 # in der Datei und stiftet Verwirrung. Der echte Wert sitzt in settings.json.
 desired="$(printf '%s' "$desired" | jq 'del(.remoteControlAtStartup)')"
 
-if [[ ${#trust_paths[@]} -eq 0 ]]; then
-    warn "no trustable paths found (PWD invalid, /workspaces missing) — workspace-trust skipped"
-else
-    for p in "${trust_paths[@]}"; do
-        desired="$(printf '%s' "$desired" | jq --arg ws "$p" '
-            .projects = ((.projects // {}) | .[$ws] = ((.[$ws] // {})
-                | .hasTrustDialogAccepted        = true
-                | .hasCompletedProjectOnboarding = true
-            ))
-        ')"
-    done
-fi
-
-trust_summary="<none>"
-if [[ ${#trust_paths[@]} -gt 0 ]]; then
-    trust_summary="${trust_paths[*]}"
-fi
 if [[ "$(printf '%s' "$current"  | jq -S .)" != \
       "$(printf '%s' "$desired"  | jq -S .)" ]]; then
-    log "patching .claude.json (remoteControl=${REMOTE_CONTROL}, trusted paths: ${trust_summary})"
+    log "patching .claude.json (remoteControl=${REMOTE_CONTROL})"
     tmp_file="$(mktemp)"
     printf '%s\n' "$desired" > "$tmp_file"
     install_for_target "$tmp_file" "$TARGET_JSON" 600


### PR DESCRIPTION
## Summary

Reworks the workspace-trust logic and lifts it to run in both lifecycle hooks.

### Trust path: only `/workspaces/*` subdirs
Drops the parent `/workspaces` entry (Claude checks trust per exact-path against cwd — parent entries are dead) and removes the resolved-workspace / realpath additions (they only added noise). For every immediate subdir of `/workspaces`, we write:

```json
".projects": {
    "<subdir>": {
        "hasTrustDialogAccepted": true,
        "hasCompletedProjectOnboarding": true
    }
}
```

### Lifted to both `postCreate` and `postStart`
- Extracted into `apply_workspace_trust` in `_lib.sh`.
- `postCreate.sh` calls it **before** the host-creds early-exit, so trust is set even when no host credentials are available.
- `postStart.sh` calls it on every container start (idempotent re-apply).

### Lifecycle commands: object notation
Switched from string form to object form for nicer task labels in dev container logs:

```json
"postCreateCommand": { "claude-code": "/usr/local/share/claude-code/postCreate.sh" }
```

### Other
- Patch bump **v1.4.1 → v1.4.2**.
- NOTES.md table row reworded; top-level README needs no change (no option table affected).

## Test plan
- [ ] CI matrices pass (autogenerated + scenarios)
- [ ] Open dev container locally: `claude` runs with no trust dialog
- [ ] Open a second repo from `/workspaces/<other>` in the same container: also no trust prompt
- [ ] Verify `.claude.json` contains `.projects["/workspaces/<repo>"]` entries with both flags set